### PR TITLE
Improve scripts

### DIFF
--- a/demo/init.sh
+++ b/demo/init.sh
@@ -606,6 +606,4 @@ printf "The subdomain for frpc is: https://$subdomain.$gaianet_domain\n"
 
 printf "Your node ID is $subdomain Please register it in your portal account to receive awards!\n"
 
-printf "\n>>> Run 'source $HOME/.wasmedge/env' to get the GaiaNet environment ready for the current terminal. <<<\n"
-
 exit 0

--- a/demo/init.sh
+++ b/demo/init.sh
@@ -165,7 +165,7 @@ cd $gaianet_base_dir
 if [ ! -f "$gaianet_base_dir/llama-api-server.wasm" ] || [ "$reinstall" -eq 1 ]; then
     printf "[+] Downloading the llama-api-server.wasm ...\n\n"
 
-    curl --progress-bar -LO https://github.com/LlamaEdge/LlamaEdge/raw/feat-files-endpoint/api-server/llama-api-server.wasm
+    curl --progress-bar -LO https://github.com/LlamaEdge/LlamaEdge/releases/latest/download/llama-api-server.wasm
 
 else
     printf "[+] Using the cached llama-api-server.wasm ...\n"
@@ -198,7 +198,7 @@ printf "\n"
 if [ ! -f "$gaianet_base_dir/registry.wasm" ] || [ "$reinstall" -eq 1 ]; then
     printf "[+] Downloading the registry.wasm ...\n\n"
     curl -s -LO https://github.com/GaiaNet-AI/gaianet-node/raw/main/utils/registry/registry.wasm
-else 
+else
     printf "[+] Using cached registry ...\n"
 fi
 printf "[+] Generating node ID ...\n"

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -123,7 +123,7 @@ cmd="wasmedge --dir .:./dashboard \
   --model-name $chat_model_stem,$embedding_model_stem \
   --ctx-size $chat_ctx_size,$embedding_ctx_size \
   --qdrant-url http://127.0.0.1:6333 \
-  --qdrant-collection-name "paris" \
+  --qdrant-collection-name "default" \
   --qdrant-limit 3 \
   --qdrant-score-threshold 0.4 \
   --web-ui ./ \


### PR DESCRIPTION
Major change:

- Update the download url of `llama-api-server.wasm` to the latest release.
- Remove `jq` command from `init.sh`.
- Update Qdrant collection name to `default`.
- Allow custom port for LlamaEdge API server.
- Remove unused prompt for activating `WasmEdge` and `Qdrant` binaries in the end of`init.sh`.