### PR TITLE
Improve the gaianet script

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
     "description": "The default GaiaNet node config with a Phi-3-mini-4k model and a Paris tour guide knowledge base.",
     "chat": "https://huggingface.co/second-state/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q5_K_M.gguf",
     "prompt_template": "phi-3-chat",
-    "reverse_prompt": "",
+    "reverse_prompt": "<|end|>",
     "chat_ctx_size": "4096",
     "system_prompt": "You are a helpful, respectful and honest assistant. Always answer accurately, while being safe.",
     "embedding": "https://huggingface.co/second-state/All-MiniLM-L6-v2-Embedding-GGUF/resolve/main/all-MiniLM-L6-v2-ggml-model-f16.gguf",

--- a/gaianet
+++ b/gaianet
@@ -1009,6 +1009,16 @@ case $subcommand in
             update_config prompt_template $prompt_template
         fi
 
+        # update prompt template
+        if [ -n "$reverse_prompt" ]; then
+            printf "[+] Updating the reverse prompt of chat model ...\n"
+            printf "    * Old template: $(awk -F'"' '/"reverse_prompt":/ {print $4}' $gaianet_base_dir/config.json)\n"
+            info "    * New template: $reverse_prompt"
+
+            # update
+            update_config reverse_prompt $reverse_prompt
+        fi
+
         # update port
         if [ -n "$port" ]; then
             printf "[+] Updating the port of LlamaEdge API Server ...\n"

--- a/gaianet
+++ b/gaianet
@@ -541,7 +541,7 @@ start() {
 
     # Add reverse prompt if it exists
     if [ -n "$reverse_prompt" ]; then
-        cmd+=("--reverse_prompt" "$reverse_prompt")
+        cmd+=("--reverse-prompt" "$reverse_prompt")
     fi
 
     printf "    Run the following command to start the LlamaEdge API Server:\n\n"

--- a/gaianet
+++ b/gaianet
@@ -603,6 +603,7 @@ start() {
             info "    LlamaEdge API Server started with pid: $llamaedge_pid"
         fi
 
+        sleep 10
         status_code=$(curl -o /dev/null -s -w "%{http_code}\n" \
             -X POST http://localhost:$llamaedge_port/v1/chat/completions \
             -H 'accept:application/json' \

--- a/gaianet
+++ b/gaianet
@@ -610,7 +610,9 @@ start() {
             -H 'Content-Type: application/json' \
             -d "{\"messages\":[{\"role\":\"user\", \"content\": \"What is your name?\"}], \"model\":\"$chat_model_stem\"}")
 
-        if [ "$status_code" -eq 200 ]; then
+        curl_exit_status=$?
+
+        if [ $curl_exit_status -eq 0 ] && [ "$status_code" -eq 200 ]; then
             break
         else
             # stop the api-server


### PR DESCRIPTION
- [X] Add sleep after wasmedge server starts so that `curl` will get meaningful data
- [x] Handle "connection refused" in `curl` response if wasmedge does not  start up
- [x] Fix `gaianet config --reverse-prompt` command
- [x] ~~Enclose reverse prompt from `config.json` into "" on wasmedge CLI command.~~ Correct the typo `--reverse_prompt` to `--reverse-prompt`.