### PR TITLE
Bug: added error handling for unsupported architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -226,6 +226,9 @@ if [ ! -f "$gaianet_base_dir/bin/qdrant" ] || [ "$reinstall" -eq 1 ]; then
             rm $gaianet_base_dir/qdrant-aarch64-apple-darwin.tar.gz
 
             info "      The Qdrant binary is downloaded in $gaianet_base_dir/bin"
+        else
+            error " * Unsupported architecture: $target, only support x86_64 and arm64 on MacOS"
+            exit 1
         fi
 
     elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
@@ -245,6 +248,9 @@ if [ ! -f "$gaianet_base_dir/bin/qdrant" ] || [ "$reinstall" -eq 1 ]; then
             rm $gaianet_base_dir/qdrant-aarch64-unknown-linux-musl.tar.gz
 
             info "      The Qdrant binary is downloaded in $gaianet_base_dir/bin"
+        else
+            error " * Unsupported architecture: $target, only support x86_64 and aarch64 on Linux"
+            exit 1
         fi
 
     elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
@@ -362,6 +368,9 @@ if [ "$(uname)" == "Darwin" ]; then
         rm $gaianet_base_dir/gaianet_domain_${gaianet_domain_version}_darwin_arm64.tar.gz
 
         info "      gaianet-domain is downloaded in $gaianet_base_dir"
+    else
+        error " * Unsupported architecture: $target, only support x86_64 and arm64 on MacOS"
+        exit 1
     fi
 
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
@@ -380,6 +389,9 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
         rm $gaianet_base_dir/gaianet_domain_${gaianet_domain_version}_linux_arm64.tar.gz
 
         info "      gaianet-domain is downloaded in $gaianet_base_dir"
+    else
+        error " * Unsupported architecture: $target, only support x86_64 and arm64 on Linux"
+        exit 1
     fi
 
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then


### PR DESCRIPTION
The install script fails with an obscure error where it can't find a file if installation takes place on an architecture not supported. This fix adds an else statement to the architecture checks and prints an error message if the current architecture isn't supported.