### PR TITLE
Update install.sh | Bump qdrant version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ ggml_bn="b4466"
 vector_version="0.38.0"
 dashboard_version="v3.1"
 assistant_version="0.4.1"
-qdrant_version="v1.11.4"
+qdrant_version="v1.13.2"
 
 # 0: do not reinstall, 1: reinstall
 reinstall=0


### PR DESCRIPTION
Qdrant version needs to be updated as the older version of Qdrant installed with gaianet does not support snapshots created using newer version of qdrant.