### PR TITLE
docs: fix typo in Russian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </a>
 </p>
 
-[Japanese(日本語)](README-ja.md) | [Chinese(中文)](README-cn.md) | [Korean(한국어)](README-kr.md) | [Turkish (Türkçe)](README-tr.md) | [Farsi(فارسی)](README-fa.md) | [Arabic (العربية)](README-ar.md) | [Indonesia](README-id.md) | [Russian (русскийة)](README-ru.md) | [Portuguese (português)](README-pt.md) | We need your help to translate this README into your native language.
+[Japanese(日本語)](README-ja.md) | [Chinese(中文)](README-cn.md) | [Korean(한국어)](README-kr.md) | [Turkish (Türkçe)](README-tr.md) | [Farsi(فارسی)](README-fa.md) | [Arabic (العربية)](README-ar.md) | [Indonesia](README-id.md) | [Russian (русский)](README-ru.md) | [Portuguese (português)](README-pt.md) | We need your help to translate this README into your native language.
 
 Like our work? ⭐ Star us!
 


### PR DESCRIPTION
I noticed a issue in the translation section where the "ة" character appeared in the Russian language line, which is an Arabic letter and shouldn't be there. I’ve replaced it with the correct "русский" to ensure consistency.