### PR TITLE
docs: fix typo in Russian translation

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -12,7 +12,7 @@
   </a>
 </p>
 
-[Japanese(日本語)](README-ja.md) | [Chinese(中文)](README-cn.md) | [Turkish (Türkçe)](README-tr.md) | [Arabic (العربية)](README-ar.md) | [Russian (русскийة)](README-ru.md) | Нам нужна ваша помощь, чтобы перевести этот README на ваш родной язык.
+[Japanese(日本語)](README-ja.md) | [Chinese(中文)](README-cn.md) | [Turkish (Türkçe)](README-tr.md) | [Arabic (العربية)](README-ar.md) | [Russian (русский)](README-ru.md) | Нам нужна ваша помощь, чтобы перевести этот README на ваш родной язык.
 
 Нравится наша работа? ⭐ Поставьте нам звезду!
 


### PR DESCRIPTION
I noticed a issue in the translation section where the "ة" character appeared in the Russian language line, which is an Arabic letter and shouldn't be there. I’ve replaced it with the correct "русский" to ensure consistency.