### PR TITLE
fix: add missing stop_force and store_force helpers

### DIFF
--- a/gaianet
+++ b/gaianet
@@ -452,6 +452,25 @@ update_config() {
 
 # * start subcommand
 
+# Added by Aboyeji Isaac:
+# stop_force() and store_force() were missing but called inside start_chat_server().
+# These helper functions prevent crashes by force-stopping processes and saving logs.
+
+stop_force() {
+    echo "🛑 Forcing stop of chat server..."
+    pkill -9 wasmedge || true   # kill any leftover chat server process
+    rm -f "$gaianet_base_dir/chat_server.pid"
+}
+
+store_force() {
+    echo "💾 Forcing store of chat server logs/state..."
+    # For now, just move logs so they are preserved
+    timestamp=$(date +"%Y%m%d_%H%M%S")
+    if [ -f "$log_dir/chat-server.log" ]; then
+        cp "$log_dir/chat-server.log" "$log_dir/chat-server_$timestamp.log"
+    fi
+}
+
 start_chat_server() {
     # parse cli options for chat model
     url_chat_model=$(awk -F'"' '/"chat":/ {print $4}' $gaianet_base_dir/config.json)


### PR DESCRIPTION
## Fix missing `stop_force` and `store_force` helpers

This PR fixes [#194](https://github.com/GaiaNet-AI/gaianet-node/issues/194).

### Problem
The script called `stop_force` and `store_force` inside `start_chat_server()`, but neither function was defined.  
This caused crashes such as:
/home/viperx808/gaianet/bin/gaianet: line 588: store_force: command not found


### Solution
- Added `stop_force()` to safely kill any leftover `wasmedge` process and remove stale PID files.  
- Added `store_force()` to preserve chat server logs with timestamping, preventing data loss.  

### Testing
- Ran `gaianet-node start --log_level=debug` locally.  
- Script no longer fails at line 588.  
- Verified that logs are properly preserved and server shutdowns are safe.

---

✅ This makes the node startup more stable and prevents unrecoverable crashes.
