### PR TITLE
fix: correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ gaianet stop --base $HOME/gaianet.alt
 
 ### Update configuration
 
-Using `gaianet config` subcommand can update the key fields defined in the `config.json` file. You MUST run `gaianet init` again after you update the configuartion.
+Using `gaianet config` subcommand can update the key fields defined in the `config.json` file. You MUST run `gaianet init` again after you update the configuration.
 
 To update the `chat` field, for example, use the following command:
 


### PR DESCRIPTION
## Summary

Fixed a typo in `README.md`:

- **Line 226**: `configuartion` → `configuration`

### Context

The sentence previously read:
> You MUST run `gaianet init` again after you update the **configuartion**.

It now correctly reads:
> You MUST run `gaianet init` again after you update the **configuration**.

This is a straightforward spelling correction that improves documentation quality.